### PR TITLE
Fix Minifier Options Explanation in Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ minify paths...  {
 | Minifier(s)   | Option                    | Value         | Description |
 | ------------- |-------------              | ----------    | ----------- |
 | css, svg      | decimals                  | number        | Preserves default attribute values. |
-| xml, html     | keep_whitespace           | true\|false   | Preserve `html`, `head` and `body` tags. |
+| xml, html     | keep_whitespace           | true\|false   | Preserves whitespace between inline tags but still collapse multiple whitespace characters into one. |
 | html          | keep_end_tags             | true\|false   | Preserves all end tags. |
-| html          | keep_document_tags        | true\|false   | Preserves whitespace between inline tags but still collapse multiple whitespace characters into one. |
+| html          | keep_document_tags        | true\|false   | Preserve `html`, `head` and `body` tags. |
 | html          | keep_default_attr_vals    | true\|false   | Preserves default value attributes. |
 | html          | keep_conditional_comments    | true\|false   | Preserves all IE conditional comments. |
 


### PR DESCRIPTION
The description of `keep_whitespace` and `keep_document_tags` minifier are swapped each other.