### PR TITLE
Add Example to Customize Minifier Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,12 @@ minify /assets {
     if {path} not_match ^(\/assets\/js).*
 }
 ```
+
+Customize the minifier options:
+
+```
+minify {
+    html keep_document_tags
+    html keep_whitespace
+}
+```


### PR DESCRIPTION
Based on my experience with Caddyfiles syntax, people will try:

1.
```
minify {
    minifier html keep_whitespace
}
```

2.
```
minify {
    html {
        keep_whitespace
    }
}
```

Both are error, since there are no explanation.
This PR will gives example on adding minifier options on readme.